### PR TITLE
See how disciplines are present across duplicates

### DIFF
--- a/harvester/edurep/utils.py
+++ b/harvester/edurep/utils.py
@@ -50,6 +50,8 @@ def get_edurep_query_seeds(query):
         except ValueError as exc:
             err.warning("Invalid XML:", exc, search.uri)
     seeds = {}
+    duplicate_counts = 0
+    overwrite_counts = 0
     for seed in sorted(results, key=lambda rsl: rsl["publisher_date"] or ""):
         # Some records in Edurep do not have any known URL
         # As we can't possibly process those we ignore them (silently)
@@ -66,14 +68,20 @@ def get_edurep_query_seeds(query):
         for field in UNESCAPE_TARGET_FIELDS:
             if seed[field]:
                 seed[field] = unescape(seed[field])
+        if seed["title"] in seeds:
+            duplicate_counts += 1
+            if len(seeds[seed["title"]]["disciplines"]) and not len(seed["disciplines"]):
+                overwrite_counts += 1
+            #print(len(seeds[seed["url"]]["disciplines"]), len(seed["disciplines"]))
         # We deduplicate some fields
         seed["lom_educational_levels"] = list(set(seed["lom_educational_levels"]))
         seed["educational_levels"] = list(set(seed["educational_levels"]))
         seed["humanized_educational_levels"] = list(set(seed["humanized_educational_levels"]))
         seed["disciplines"] = list(set(seed["disciplines"]))
         seed["humanized_disciplines"] = list(set(seed["humanized_disciplines"]))
-        # And deduplicate entire seeds based on URL
-        seeds[seed["url"]] = seed
+        # And deduplicate entire seeds based on title
+        seeds[seed["title"]] = seed
+    print("Counts:", overwrite_counts, duplicate_counts)
     return seeds.values()
 
 

--- a/harvester/edurep/utils.py
+++ b/harvester/edurep/utils.py
@@ -52,6 +52,7 @@ def get_edurep_query_seeds(query):
     seeds = {}
     duplicate_counts = 0
     overwrite_counts = 0
+    missing_disciplines_counts = 0
     for seed in sorted(results, key=lambda rsl: rsl["publisher_date"] or ""):
         # Some records in Edurep do not have any known URL
         # As we can't possibly process those we ignore them (silently)
@@ -81,7 +82,9 @@ def get_edurep_query_seeds(query):
         seed["humanized_disciplines"] = list(set(seed["humanized_disciplines"]))
         # And deduplicate entire seeds based on title
         seeds[seed["title"]] = seed
-    print("Counts:", overwrite_counts, duplicate_counts)
+        if not len(seed["disciplines"]):
+            missing_disciplines_counts += 1
+    print("Counts:", overwrite_counts, duplicate_counts, missing_disciplines_counts)
     return seeds.values()
 
 


### PR DESCRIPTION
Here we deduplicate based on title (the most aggressive way possible). This starkly decreases documents (with about 1/3). So that alone would improve the rate at which materials without disciplines occur, but not because we "found" any missing disciplines. Just because there are less materials in the first place. The required disciplines from Sharekit are in that sense still missing from Edurep. Only one material lost some disciplines (but not all), because there was a duplicate based on the title of the documents.